### PR TITLE
MacOS patch

### DIFF
--- a/src/serialbox/core/MetainfoValueImpl.cpp
+++ b/src/serialbox/core/MetainfoValueImpl.cpp
@@ -296,6 +296,11 @@ std::int64_t MetainfoValueImpl::as() const {
 }
 
 template <>
+long MetainfoValueImpl::as() const {
+  return internal::makePrimitiveOf<std::int64_t>(any_, type_);
+}
+
+template <>
 float MetainfoValueImpl::as() const {
   return internal::makePrimitiveOf<float>(any_, type_);
 }

--- a/src/serialbox/core/Type.h
+++ b/src/serialbox/core/Type.h
@@ -88,7 +88,7 @@ template <class T>
 struct IsSupported {
 
   /// \brief Set of supported types
-  using SupportedTypesSet = boost::mpl::set<bool, int, std::int64_t, float, double, std::string>;
+  using SupportedTypesSet = boost::mpl::set<bool, int, std::int64_t, long, float, double, std::string>;
 
   /// \brief True iff the type is supported
   constexpr static bool value = boost::mpl::has_key<SupportedTypesSet, T>::type::value;
@@ -144,6 +144,11 @@ struct ToTypeID<std::int32_t> {
 
 template <>
 struct ToTypeID<std::int64_t> {
+  static constexpr TypeID value = TypeID::Int64;
+};
+
+template <>
+struct ToTypeID<long> {
   static constexpr TypeID value = TypeID::Int64;
 };
 

--- a/test/serialbox/core/UnittestMetainfoValueImpl.cpp
+++ b/test/serialbox/core/UnittestMetainfoValueImpl.cpp
@@ -40,6 +40,11 @@ std::pair<int, int> getValuePair<int>() {
 }
 
 template <>
+std::pair<long, long> getValuePair<long>() {
+  return std::make_pair<std::int64_t, std::int64_t>(1.0, 2.2);
+}
+
+template <>
 std::pair<std::int64_t, std::int64_t> getValuePair<std::int64_t>() {
   return std::make_pair<std::int64_t, std::int64_t>(1, 2);
 }
@@ -103,15 +108,15 @@ TYPED_TEST(MetainfoValueImplTest, Constrcution) {
   TypeParam&& v1_rref = getValue1();
   MetainfoValueImpl value1_rref(v1_rref);
   EXPECT_EQ(value1_rref.as<TypeParam>(), pair.first);
-  
+
   // Construct with Array
   Array<TypeParam> array = {pair.first, pair.second};
-  MetainfoValueImpl valueArray(array);  
+  MetainfoValueImpl valueArray(array);
 
   // Explicit conversion
   EXPECT_EQ(value1.as<TypeParam>(), pair.first);
   EXPECT_EQ(value2.as<TypeParam>(), pair.second);
-  
+
   EXPECT_EQ(valueArray.as<Array<TypeParam>>()[0], pair.first);
   EXPECT_EQ(valueArray.as<Array<TypeParam>>()[1], pair.second);
 
@@ -120,7 +125,7 @@ TYPED_TEST(MetainfoValueImplTest, Constrcution) {
   TypeParam v2 = value2;
   EXPECT_TRUE(v1 == pair.first);
   EXPECT_TRUE(v2 == pair.second);
-  
+
   // Conversion to different type
 
   //
@@ -202,15 +207,15 @@ TYPED_TEST(MetainfoValueImplTest, Constrcution) {
     EXPECT_EQ(value2.as<double>(), 55.0);
     EXPECT_EQ(value2.as<std::string>(), "55");
   }
-  
+
   MetainfoValueImpl valueInvalid;
-  
+
   // Conversion from Invalid -> Exception
   EXPECT_THROW(valueInvalid.as<TypeParam>(), Exception);
-  
+
   // Conversion from non-array type to array -> Exception
-  EXPECT_THROW(valueInvalid.as<Array<TypeParam>>(), Exception);  
-  
+  EXPECT_THROW(valueInvalid.as<Array<TypeParam>>(), Exception);
+
   // Swap
   value1.swap(value2);
   EXPECT_EQ(value1.as<TypeParam>(), pair.second);


### PR DESCRIPTION
Maps `long` to `std::int64_t`. Something like this is required to build on MacOS.

Resolves #242.