### PR TITLE
Remove references to serialbox2 everywhere

### DIFF
--- a/docs/sphinx/Building.rst
+++ b/docs/sphinx/Building.rst
@@ -21,7 +21,7 @@ To build Serialbox you need a C++11 toolchain, `CMake <http://www.cmake.org/>`_ 
 
    .. code-block:: console
 
-     $ git clone https://github.com/eth-cscs/serialbox.git
+     $ git clone https://github.com/GridTools/serialbox.git
      $ cd serialbox
      $ mkdir build
      $ cd build
@@ -266,5 +266,4 @@ External project specific variables
 
 **NETCDF_ROOT**:PATH
   Install directory of `NetCDF-4 <http://www.unidata.ucar.edu/software/netcdf/>`_.
-
 

--- a/docs/sphinx/Building.rst
+++ b/docs/sphinx/Building.rst
@@ -21,8 +21,8 @@ To build Serialbox you need a C++11 toolchain, `CMake <http://www.cmake.org/>`_ 
 
    .. code-block:: console
 
-     $ git clone https://github.com/eth-cscs/serialbox2.git
-     $ cd serialbox2
+     $ git clone https://github.com/eth-cscs/serialbox.git
+     $ cd serialbox
      $ mkdir build
      $ cd build
 
@@ -45,7 +45,7 @@ To build Serialbox you need a C++11 toolchain, `CMake <http://www.cmake.org/>`_ 
 
    The underlying build tool can be invoked directly, of course, e.g ``make -j4``.
 
-#. After Serialbox has finished building, install it from the build directory. The files will be installed into the top-level ``install`` directory (i.e ``serialbox2/install``).
+#. After Serialbox has finished building, install it from the build directory. The files will be installed into the top-level ``install`` directory (i.e ``serialbox/install``).
 
    .. code-block:: console
 

--- a/docs/sphinx/Documentation.rst
+++ b/docs/sphinx/Documentation.rst
@@ -45,5 +45,5 @@ GitHub provides the ability to upload your website to `GitHub Pages <https://pag
 
   $ make deploy-docs
   
-To view your website, head to http://username.github.io/serialbox2 . You may need to adjust the GitHub settings of your Serialbox repository: ``"Settings"`` -> ``"GitHub Pages"`` set the ``"Source"`` to ``"gh-pages branch"`` to enable GitHub Pages.
+To view your website, head to http://username.github.io/serialbox . You may need to adjust the GitHub settings of your Serialbox repository: ``"Settings"`` -> ``"GitHub Pages"`` set the ``"Source"`` to ``"gh-pages branch"`` to enable GitHub Pages.
 

--- a/docs/sphinx/Python.rst
+++ b/docs/sphinx/Python.rst
@@ -141,7 +141,7 @@ To read ``foo`` at Savepoint with ``time=1``, you can use one of the `read` meth
 Quick start - Visualization
 ---------------------------
 
-To help visualizing the data serialbox2 contains a built-in :class:`Visualizer <serialbox.visualizer.Visualizer>` based on `matplotlib <https://matplotlib.org/>`_ . The visualizer is able to visualize any 3D numpy field and expects two arguments: a reference to the numpy field and the name of the plot. For exmaple, to visualize the field ``pp``:
+To help visualizing the data serialbox contains a built-in :class:`Visualizer <serialbox.visualizer.Visualizer>` based on `matplotlib <https://matplotlib.org/>`_ . The visualizer is able to visualize any 3D numpy field and expects two arguments: a reference to the numpy field and the name of the plot. For exmaple, to visualize the field ``pp``:
 
   >>> from serialbox.visualizer import Visualizer
   >>> Visualizer(pp, 'pp')

--- a/docs/sphinx/Python.rst
+++ b/docs/sphinx/Python.rst
@@ -141,7 +141,7 @@ To read ``foo`` at Savepoint with ``time=1``, you can use one of the `read` meth
 Quick start - Visualization
 ---------------------------
 
-To help visualizing the data serialbox contains a built-in :class:`Visualizer <serialbox.visualizer.Visualizer>` based on `matplotlib <https://matplotlib.org/>`_ . The visualizer is able to visualize any 3D numpy field and expects two arguments: a reference to the numpy field and the name of the plot. For exmaple, to visualize the field ``pp``:
+To help visualizing the data, Serialbox contains a built-in :class:`Visualizer <serialbox.visualizer.Visualizer>` based on `matplotlib <https://matplotlib.org/>`_ . The visualizer is able to visualize any 3D numpy field and expects two arguments: a reference to the numpy field and the name of the plot. For exmaple, to visualize the field ``pp``:
 
   >>> from serialbox.visualizer import Visualizer
   >>> Visualizer(pp, 'pp')

--- a/examples/fortran/simple/m_ser.F90
+++ b/examples/fortran/simple/m_ser.F90
@@ -96,7 +96,7 @@ USE utils_ppser, ONLY:  &
           prefix_ref='SerialboxTest',rprecision=rprecision,rperturb=1.0e-5_8)
     call fs_create_savepoint('sp1', ppser_savepoint)
     call ppser_set_mode(2)
-    ! file: /Volumes/MeteoSwissCode/serialbox2/examples/Fortran/with_pp_ser/m_ser.f90 lineno: #40
+    ! file: /Volumes/MeteoSwissCode/serialbox/examples/Fortran/with_pp_ser/m_ser.f90 lineno: #40
     SELECT CASE ( ppser_get_mode() )
       CASE(0)
         call fs_write_field(ppser_serializer, ppser_savepoint, 'ser_a', a)

--- a/examples/gridtools/smagorinsky/CMakeLists.txt
+++ b/examples/gridtools/smagorinsky/CMakeLists.txt
@@ -32,7 +32,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # We call the find_package-module of Serialbox and gridtools and set the include directories
 #
 find_package(Serialbox REQUIRED HINTS
-    "${CMAKE_CURRENT_LIST_DIR}/../serialbox2/install/cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/../serialbox/install/cmake"
     "${SERIALBOX_ROOT}/cmake"
     "${SERIALBOX_DIR}/cmake"
     "$ENV{SERIALBOX_ROOT}/cmake")

--- a/src/serialbox-fortran/m_ser_ftg.f90
+++ b/src/serialbox-fortran/m_ser_ftg.f90
@@ -7,7 +7,7 @@
 !
 !------------------------------------------------------------------------------
 !
-!+ This module contains the FortranTestGenerator (FTG) frontend of Serialbox2.
+!+ This module contains the FortranTestGenerator (FTG) frontend of serialbox.
 !+ For FTG see https://github.com/fortesg/fortrantestgenerator
 !
 !------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ MODULE m_ser_ftg
 ! Description:
 !
 !   This module contains simplified wrapper subroutines for the Fortran interface
-!   of Serialbox2 (m_serialize.f90) to be used by the FortranTestGenerator
+!   of serialbox (m_serialize.f90) to be used by the FortranTestGenerator
 !   (https://github.com/fortesg/fortrantestgenerator), plus additional subroutines
 !   for allocating array variables based on the stored sizes and bounds.
 !

--- a/src/serialbox-fortran/m_ser_ftg.f90
+++ b/src/serialbox-fortran/m_ser_ftg.f90
@@ -19,7 +19,7 @@ MODULE m_ser_ftg
 ! Description:
 !
 !   This module contains simplified wrapper subroutines for the Fortran interface
-!   of serialbox (m_serialize.f90) to be used by the FortranTestGenerator
+!   of Serialbox (m_serialize.f90) to be used by the FortranTestGenerator
 !   (https://github.com/fortesg/fortrantestgenerator), plus additional subroutines
 !   for allocating array variables based on the stored sizes and bounds.
 !

--- a/src/serialbox-fortran/m_ser_ftg.f90
+++ b/src/serialbox-fortran/m_ser_ftg.f90
@@ -7,7 +7,7 @@
 !
 !------------------------------------------------------------------------------
 !
-!+ This module contains the FortranTestGenerator (FTG) frontend of serialbox.
+!+ This module contains the FortranTestGenerator (FTG) frontend of Serialbox.
 !+ For FTG see https://github.com/fortesg/fortrantestgenerator
 !
 !------------------------------------------------------------------------------

--- a/src/serialbox-fortran/m_ser_ftg_cmp.f90
+++ b/src/serialbox-fortran/m_ser_ftg_cmp.f90
@@ -7,7 +7,7 @@
 !
 !------------------------------------------------------------------------------
 !
-!+ This module contains the FortranTestGenerator (FTG) frontend of Serialbox2.
+!+ This module contains the FortranTestGenerator (FTG) frontend of serialbox.
 !+ For FTG see https://github.com/fortesg/fortrantestgenerator
 !
 !------------------------------------------------------------------------------

--- a/src/serialbox-fortran/m_ser_ftg_cmp.f90
+++ b/src/serialbox-fortran/m_ser_ftg_cmp.f90
@@ -7,7 +7,7 @@
 !
 !------------------------------------------------------------------------------
 !
-!+ This module contains the FortranTestGenerator (FTG) frontend of serialbox.
+!+ This module contains the FortranTestGenerator (FTG) frontend of Serialbox.
 !+ For FTG see https://github.com/fortesg/fortrantestgenerator
 !
 !------------------------------------------------------------------------------

--- a/src/serialbox-python/sdb/sdbgui/mainwindow.py
+++ b/src/serialbox-python/sdb/sdbgui/mainwindow.py
@@ -34,7 +34,7 @@ from sdbgui.tabstate import TabState
 
 
 class MainWindow(QMainWindow):
-    OnlineHelpUrl = QUrl("https://eth-cscs.github.io/serialbox2/sdb.html")
+    OnlineHelpUrl = QUrl("https://eth-cscs.github.io/serialbox/sdb.html")
 
     def __init__(self):
         super().__init__()

--- a/src/serialbox-python/sdb/sdbgui/mainwindow.py
+++ b/src/serialbox-python/sdb/sdbgui/mainwindow.py
@@ -34,7 +34,7 @@ from sdbgui.tabstate import TabState
 
 
 class MainWindow(QMainWindow):
-    OnlineHelpUrl = QUrl("https://eth-cscs.github.io/serialbox/sdb.html")
+    OnlineHelpUrl = QUrl("https://GridTools.github.io/serialbox/sdb.html")
 
     def __init__(self):
         super().__init__()

--- a/tools/cscs-scripts/submit.kesch.slurm
+++ b/tools/cscs-scripts/submit.kesch.slurm
@@ -1,10 +1,10 @@
 #!/bin/bash
-#SBATCH --job-name=serialbox2-unittest
+#SBATCH --job-name=serialbox-unittest
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --ntasks-per-socket=1
-#SBATCH --output=serialbox2-unittest.out
+#SBATCH --output=serialbox-unittest.out
 #SBATCH --partition=debug
 #SBATCH --time=00:2:00
 #SBATCH --cpus-per-task=12


### PR DESCRIPTION
There were some left-over references to serialbox2 instead of serialbox.