### PR TITLE
pp_ser: avoid explicit conversion of native strings to bytes

### DIFF
--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -48,13 +48,6 @@ __date__ = 'Sun Mar 23 22:06:44 2014'
 __email__ = 'oliver.fuhrer@meteoswiss.ch'
 
 
-def to_ascii(text):
-    if sys.version_info[0] == 3:
-        return bytes(text, 'ascii')
-    else:
-        return str(text)
-
-
 def filter_fortran(f):
     return (f.split('.')[-1].lower() in ['f90', 'inc', 'incf', 'f', 'f03'])
 
@@ -944,10 +937,10 @@ class PpSer:
         self.parse(generate=True)   # second pass, preprocess
         # write output
         if self.outfile != '':
-            output_file = tempfile.NamedTemporaryFile(delete=False)
+            output_file = tempfile.NamedTemporaryFile(mode='w+', delete=False)
             # same permissions as infile
             os.chmod(output_file.name, os.stat(self.infile).st_mode)
-            output_file.write(to_ascii(self.__outputBuffer))
+            output_file.write(self.__outputBuffer)
             output_file.close()
             useit = True
             if os.path.isfile(self.outfile) and not self.identical:


### PR DESCRIPTION
Currently, `pp_ser` fails to process source files containing Unicode character with Python 3. For example:
```console
UnicodeEncodeError: 'ascii' codec can't encode character '\u2013' in position 604: ordinal not in range(128)
```
This is normally not a problem if we use Python 2. The reason is that in the case of Python 2 files are read and written using the same encoding `locale.getpreferredencoding()` (usually `UTF-8`) but in the case of Python 3, strings that are read with the `locale.getpreferredencoding()` encoding are written using `ascii`.

One way to fix the problem is to replace `ascii` with `locale.getpreferredencoding()` inside the `to_ascii` function (the name of the function is misleading in the case of Python2, therefore I would rename it to `to_bytes`).

The second approach, which is implemented in this PR, is to eliminate the explicit conversion of strings. All we need to do is to open the temporary file in the text mode (the default on is `'w+b'`).