### PR TITLE
Fix issues with install on M1 Mac's

### DIFF
--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -72,7 +72,7 @@ class CMakeBuild(build_ext):
             from distutils import sysconfig
             vars = sysconfig.get_config_vars()
             vars["SO"] = ".dylib"
-            vars["EXT_SUFFIX"] = vars["SO"]
+            vars["EXT_SUFFIX"] = ".dylib"
 
         if self.compiler.compiler_type != "msvc":
             # Using Ninja-build since it a) is available as a wheel and b)


### PR DESCRIPTION
The `pip install .` did not work on my M1 Mac. This fix did the trick.