### PR TITLE
Silence Deprecation Warning related to np.bool

### DIFF
--- a/src/serialbox-python/serialbox/type.py
+++ b/src/serialbox-python/serialbox/type.py
@@ -51,7 +51,7 @@ class TypeID(Enum):
     ArrayOfString = Array | String
 
 
-BooleanTypes = (bool, np.bool_,)
+BooleanTypes = (bool,)
 Int32Types = (int, np.int8, np.int16, np.int32, np.uint8, np.uint16, np.uint32,)
 Int64Types = (np.int64, np.uint64,)
 Float32Types = (np.float32,)
@@ -80,7 +80,7 @@ def typeID2numpy(typeid):
     """Convert serialbox.TypeID to numpy.dtype
     """
     if typeid == TypeID.Boolean:
-        return np.bool_
+        return bool
     elif typeid == TypeID.Int32:
         return np.int32
     elif typeid == TypeID.Int64:

--- a/src/serialbox-python/serialbox/type.py
+++ b/src/serialbox-python/serialbox/type.py
@@ -51,7 +51,7 @@ class TypeID(Enum):
     ArrayOfString = Array | String
 
 
-BooleanTypes = (bool, np.bool,)
+BooleanTypes = (bool, np.bool_,)
 Int32Types = (int, np.int8, np.int16, np.int32, np.uint8, np.uint16, np.uint32,)
 Int64Types = (np.int64, np.uint64,)
 Float32Types = (np.float32,)
@@ -80,7 +80,7 @@ def typeID2numpy(typeid):
     """Convert serialbox.TypeID to numpy.dtype
     """
     if typeid == TypeID.Boolean:
-        return np.bool
+        return np.bool_
     elif typeid == TypeID.Int32:
         return np.int32
     elif typeid == TypeID.Int64:

--- a/test/serialbox-python/serialbox/test_serializer.py
+++ b/test/serialbox-python/serialbox/test_serializer.py
@@ -344,7 +344,7 @@ class TestSerializer(unittest.TestCase):
         #
         # Setup fields
         #
-        field_bool = np.ndarray(dtype=np.bool, shape=[N, N, N])
+        field_bool = np.ndarray(dtype=bool, shape=[N, N, N])
         field_int32 = np.ndarray(dtype=np.int32, shape=[N, N, N])
         field_int64 = np.ndarray(dtype=np.int64, shape=[N, N, N])
         field_float32 = np.ndarray(dtype=np.float32, shape=[N, N, N])


### PR DESCRIPTION
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.

 Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

**Testing**: Warning is gone for my case. 