### PR TITLE
Fix python build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,27 +96,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10" ]
+        os: [ubuntu-latest]
+        python-version: [ "3.8","3.10"]
     steps:
       - uses: actions/checkout@v3
-      - name: install requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install libboost-all-dev
+      - name: install boost
+        uses: MarkusJx/install-boost@v2.4.1
+        with:
+          boost_version: 1.74.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
             python-version: ${{ matrix.python-version }}
+            cache: 'pip'
 
-      - name: Install python dependencies
+      - name:  upgrade python
         run: |
           python -m pip install --upgrade pip setuptools wheel
 
-      - name: install python and test
+      - name: install dependencies
         run: |
               python -m venv .venv
               source .venv/bin/activate
               pip install -r src/serialbox-python/requirements.txt
               pip install src/serialbox-python
+          
+      - name: test
+        run: |  
               pytest -v test/serialbox-python/serialbox  

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,6 +127,3 @@ jobs:
 
       - name: run tests
         run: pytest -v test/serialbox-python/serialbox >> $GITHUB_STEP_SUMMARY
-
-      - name: clean up
-        run: pip uninstall --yes serialbox

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,20 +117,16 @@ jobs:
             cache: 'pip'
 
       - name:  upgrade python tools
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel
 
       - name: install dependencies
-        run: |
-              echo "installing dependencies" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              pip install -r src/serialbox-python/requirements.txt
-              pip install src/serialbox-python
+        run: pip install -r src/serialbox-python/requirements.txt
+
+      - name: build
+        run:  pip install src/serialbox-python
+
       - name: run tests
-        run: | 
-             echo "running tests" >> $GITHUB_STEP_SUMMARY
-             echo "" >> $GITHUB_STEP_SUMMARY
-             pytest -v test/serialbox-python/serialbox >> $GITHUB_STEP_SUMMARY
+        run: pytest -v test/serialbox-python/serialbox >> $GITHUB_STEP_SUMMARY
 
       - name: clean up
         run: pip uninstall --yes serialbox

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install python dependencies
         run: |
           pip3 --version
-          pip3 install --user numpy pytest
+          pip3 install --user nose numpy
       - name: Configure
         run: ccache -s
       - name: Build
@@ -126,4 +126,4 @@ jobs:
           pip3 install src/serialbox-python
       - name: Execute tests
         run: |
-          pytest -v test/serialbox-python/serialbox
+          python3 -m nose test/serialbox-python/serialbox

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,9 +101,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install boost
-        uses: MarkusJx/install-boost@v2.4.1
-        with:
-          boost_version: 1.74.0
+        if: matrix.os == "ubuntu-latest"
+        run: |
+          sudo apt-get update
+          sudo apt-get install libboost-all-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -121,7 +122,4 @@ jobs:
               source .venv/bin/activate
               pip install -r src/serialbox-python/requirements.txt
               pip install src/serialbox-python
-          
-      - name: test
-        run: |  
-              pytest -v test/serialbox-python/serialbox  
+              pytest -v test/serialbox-python/serialbox

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,16 +95,21 @@ jobs:
   build-python:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [ "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: install boost
-        if: ${{ matrix.os }} == 'ubuntu-latest'
+        if: ${{ matrix.os }} == 'macos-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install libboost-all-dev
+            brew install boost
+        else:
+          run: |
+            sudo apt-get update
+            sudo apt-get install libboost-all-dev
+
+        
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -112,14 +117,21 @@ jobs:
             python-version: ${{ matrix.python-version }}
             cache: 'pip'
 
-      - name:  upgrade python
+      - name:  upgrade python tools
         run: |
           python -m pip install --upgrade pip setuptools wheel
 
       - name: install dependencies
         run: |
-              python -m venv .venv
-              source .venv/bin/activate
+              echo "installing dependencies" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
               pip install -r src/serialbox-python/requirements.txt
               pip install src/serialbox-python
-              pytest -v test/serialbox-python/serialbox
+      - name: run tests
+        run: | 
+             echo "running tests" >> $GITHUB_STEP_SUMMARY
+             echo "" >> $GITHUB_STEP_SUMMARY
+             pytest -v test/serialbox-python/serialbox >> $GITHUB_STEP_SUMMARY
+
+      - name: clean up
+        run: pip uninstall --yes serialbox

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,16 +100,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: install boost
-        if: ${{ matrix.os }} == 'macos-latest'
+      - name: install boost on macos
+        if: ${{ matrix.os  == 'macos-latest'}}
         run: |
             brew install boost
-        else:
-          run: |
+      - name:  install boost for ubuntu
+        if: ${{ matrix.os   == 'ubuntu-latest'}}
+        run: |
             sudo apt-get update
             sudo apt-get install libboost-all-dev
-
-        
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,15 +93,15 @@ jobs:
         run: cd build && ctest --output-on-failure
 
   build-python:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8","3.10"]
+        python-version: [ "3.10"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: install boost
-        if: matrix.os == "ubuntu-latest"
+        if: ${{ matrix.os }} == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libboost-all-dev

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,12 +113,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
 
-      - name: setup python env install
+      - name: install python and test
         run: |
               python -m venv .venv
               source .venv/bin/activate
               pip install -r src/serialbox-python/requirements.txt
-
-      - name: Execute tests
-        run: |
-          pytest -v test/serialbox-python/serialbox  
+              pip install src/serialbox-python
+              pytest -v test/serialbox-python/serialbox  

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,38 +92,33 @@ jobs:
       - name: Execute tests
         run: cd build && ctest --output-on-failure
 
-  build-pip:
+  build-python:
     runs-on: ubuntu-latest
-    container: mrtravis/gridtools:${{ matrix.compiler }}
     strategy:
       matrix:
-        compiler: [gcc-7, gcc-8, gcc-9, clang-9]
-        build_type: [Debug, Release]
-        exclude:
-          - compiler: gcc-7
-            build_type: Debug
-          - compiler: gcc-8
-            build_type: Debug
-          - compiler: clang-9
-            build_type: Debug
-
+        python-version: [ "3.10" ]
     steps:
-      - uses: actions/checkout@v1
-      - name: Set defaults
+      - uses: actions/checkout@v3
+      - name: install requirements
         run: |
-          export GCC_VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2)
-          echo "FC=gfortran-${GCC_VERSION}" >> $GITHUB_ENV
-          echo "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "TEST_FORTRAN=OFF" >> $GITHUB_ENV  # default will be overwritten in the next step
+          sudo apt-get update
+          sudo apt-get install libboost-all-dev
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+
       - name: Install python dependencies
         run: |
-          pip3 --version
-          pip3 install --user nose numpy
-      - name: Configure
-        run: ccache -s
-      - name: Build
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: setup python env install
         run: |
-          pip3 install src/serialbox-python
+              python -m venv .venv
+              source .venv/bin/activate
+              pip install -r src/serialbox-python/requirements.txt
+
       - name: Execute tests
         run: |
-          python3 -m nose test/serialbox-python/serialbox
+          pytest -v test/serialbox-python/serialbox  

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,12 +118,12 @@ jobs:
       - name: Install python dependencies
         run: |
           pip3 --version
-          pip3 install --upgrade pip setuptools wheel
-          pip3 install --user nose numpy
+          pip3 install --user numpy pytest
       - name: Configure
         run: ccache -s
       - name: Build
         run: |
           pip3 install src/serialbox-python
       - name: Execute tests
-        run: python3 -m nose test/serialbox-python/serialbox
+        run: |
+          pytest -v test/serialbox-python/serialbox

--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Yannick Boetzel (yboetz), MeteoSwiss
 Rhea George (rheacangeo), Allen Institute for Artificial Intelligence (AI2)
 Elsa Germann (elsagermann), ETH Zurich (C2SM)
 Jeremy McGibbon (mcgibbon), Allen Institute for Artificial Intelligence (AI2)
+Magdalena Luz (halungge), ETH Zurich (C2SM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ if(SERIALBOX_BUILD_SHARED)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-  set(CMAKE_MACOSX_RPATH "${CMAKE_INSTALL_RPATH}")
+  set(CMAKE_MACOSX_RPATH ON)
 
   # Add the automatically determined parts of the RPATH which point to directories outside the
   # build tree to the install RPATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ if(SERIALBOX_BUILD_SHARED)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-  set(CMAKE_MACOSX_RPATH ON)
+  set(CMAKE_MACOSX_RPATH "${CMAKE_INSTALL_RPATH}")
 
   # Add the automatically determined parts of the RPATH which point to directories outside the
   # build tree to the install RPATH

--- a/src/serialbox-python/pyproject.toml
+++ b/src/serialbox-python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm[toml]", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/src/serialbox-python/pyproject.toml
+++ b/src/serialbox-python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm[toml]", "wheel"]
+requires = ["setuptools", "setuptools-scm[toml]", "wheel", "cmake"]
 build-backend = "setuptools.build_meta"

--- a/src/serialbox-python/requirements.txt
+++ b/src/serialbox-python/requirements.txt
@@ -1,0 +1,6 @@
+numpy >= 1.23
+pytest>=7.2
+nose==1.3.7
+pytest-cache>=1.0
+setuptools>=40.8.0
+wheel>=0.37.1

--- a/src/serialbox-python/requirements.txt
+++ b/src/serialbox-python/requirements.txt
@@ -1,6 +1,5 @@
 numpy >= 1.23
 pytest>=7.2
-nose==1.3.7
 pytest-cache>=1.0
 setuptools>=40.8.0
 wheel>=0.37.1

--- a/src/serialbox-python/requirements.txt
+++ b/src/serialbox-python/requirements.txt
@@ -3,3 +3,4 @@ pytest>=7.2
 pytest-cache>=1.0
 setuptools>=40.8.0
 wheel>=0.37.1
+cmake>=3.25

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -12,6 +12,7 @@ from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 
 DIR = os.path.abspath(os.path.dirname(__file__))
+print(DIR)
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
@@ -27,6 +28,7 @@ PLAT_TO_CMAKE = {
 # If you need multiple extensions, see scikit-build.
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
+        print(sourcedir)
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -2,7 +2,6 @@
 # NOTE: Serialbox does not support Windows.
 # Windows instructions in this file are inherited from the template
 # https://github.com/pybind/cmake_example/blob/master/setup.py.
-import os
 import re
 import subprocess
 import sys

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -56,6 +56,7 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
             "-DSERIALBOX_ENABLE_FORTRAN=false",
+            "-DCMAKE_BUILD_RPATH=${ORIGIN}",
             "-DSERIALBOX_ENABLE_SDB=false",
             "-DSERIALBOX_ASYNC_API=false",
 

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -51,6 +51,7 @@ class CMakeBuild(build_ext):
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
+            "-DCMAKE_MACOSX_RPATH=true",
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
             "-DSERIALBOX_ENABLE_FORTRAN=false",
             "-DCMAKE_BUILD_RPATH={}".format(origin),

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -51,9 +51,9 @@ class CMakeBuild(build_ext):
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
-            "-DCMAKE_MACOSX_RPATH=true",
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
             "-DSERIALBOX_ENABLE_FORTRAN=false",
+            "-DCMAKE_MACOSX_RPATH=true",
             "-DCMAKE_BUILD_RPATH={}".format(origin),
             "-DSERIALBOX_ENABLE_SDB=false",
             "-DSERIALBOX_ASYNC_API=false",

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -36,7 +36,7 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-
+        origin = self._get_origin()
         # required for auto-detection & inclusion of auxiliary "native" libs
         if not extdir.endswith(os.path.sep):
             extdir += os.path.sep
@@ -56,7 +56,7 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
             "-DSERIALBOX_ENABLE_FORTRAN=false",
-            "-DCMAKE_BUILD_RPATH=${ORIGIN}",
+            "-DCMAKE_BUILD_RPATH={}".format(origin),
             "-DSERIALBOX_ENABLE_SDB=false",
             "-DSERIALBOX_ASYNC_API=false",
 
@@ -136,6 +136,14 @@ class CMakeBuild(build_ext):
         subprocess.check_call(
             ["cmake", "--build", "."] + build_args, cwd=self.build_temp
         )
+
+    def _get_origin(self):
+        origin = ""
+        if sys.platform == "linux":
+            origin = "${ORIGIN}"
+        elif sys.platform == "darwin":
+            origin = "@loader_path"
+        return origin
 
 
 # The information here can also be placed in setup.cfg - better separation of

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -12,7 +12,6 @@ from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 
 DIR = os.path.abspath(os.path.dirname(__file__))
-print(DIR)
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
@@ -28,7 +27,6 @@ PLAT_TO_CMAKE = {
 # If you need multiple extensions, see scikit-build.
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
-        print(sourcedir)
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 

--- a/src/serialbox-python/setup.py
+++ b/src/serialbox-python/setup.py
@@ -53,7 +53,6 @@ class CMakeBuild(build_ext):
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
             "-DSERIALBOX_ENABLE_FORTRAN=false",
-            "-DCMAKE_MACOSX_RPATH=true",
             "-DCMAKE_BUILD_RPATH={}".format(origin),
             "-DSERIALBOX_ENABLE_SDB=false",
             "-DSERIALBOX_ASYNC_API=false",


### PR DESCRIPTION
Added `${ORIGIN}` to the build `rpath` for python build

when running the python build with pip 
```
cd src/serialbox-python
pip install .
```
the cmake build target is run, after that the shared libraries are copied from the build folder to `site_packages` folder of the python environment. Adding ` ${ORIGIN}` to the `rpath` allows `cdll.LoadLibrary`  to find dependent libraries in the current folder.