### PR TITLE
CI: fix macOS runners + build a single py3-none wheel (Python 3.14)

### DIFF
--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -43,8 +43,8 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-13 # intel
-          - macos-14 # apple silicon
+          - macos-15-intel # intel
+          - macos-15 # apple silicon
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -74,8 +74,8 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-13 # intel
-          - macos-14 # apple silicon
+          - macos-15-intel # intel
+          - macos-15 # apple silicon
     steps:
     - name: Download wheel
       uses: actions/download-artifact@v4

--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_SKIP: pp* *musllinux* cp36-* cp37-*
+          CIBW_BUILD: cp310-* # ctypes wrapper -> py3-none wheel, one interpreter per platform suffices
+          CIBW_SKIP: '*musllinux*'
           CIBW_BEFORE_BUILD_LINUX: yum -y install boost-devel
           CIBW_ARCHS_LINUX: ${{ fromJSON('["x86_64", "aarch64"]')[matrix.os == 'ubuntu-24.04-arm'] }} # poor man ternary https://github.com/orgs/community/discussions/25725#discussioncomment-3248924
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'Programming Language :: Python :: Implementation :: CPython',
   'Topic :: File Formats',
   'Topic :: Scientific/Engineering :: Atmospheric Science',
@@ -62,6 +63,7 @@ cmake.args = [
     "-DSERIALBOX_ASYNC_API=false"
 ]
 wheel.expand-macos-universal-tags = true
+wheel.py-api = "py3"  # ctypes wrapper, no libpython linkage: one wheel works for all Python 3
 wheel.install-dir = "serialbox"
 wheel.packages = []
 wheel.license-files = []


### PR DESCRIPTION
Two related fixes to the wheel deploy workflow.

### 1. Replace the retired `macos-13` runner
GitHub retired the `macos-13` image, so the wheel build/test jobs pinned to it fail. Both the `build_wheels` and `test_wheels` matrices now use:

- `macos-13` → `macos-15-intel` (keeps native x86_64 wheels; the standard free Intel runner)
- `macos-14` → `macos-15` (arm64, pinned)

### 2. Build a single `py3-none` wheel per platform (adds Python 3.14)
serialbox4py is a **ctypes** wrapper around `libSerialboxC` — there is no CPython C-extension and nothing links against `libpython`, so the wheel binary depends only on the platform, not the Python ABI. We now:

- set `wheel.py-api = "py3"` in `[tool.scikit-build]`
- build on a single interpreter per platform (`CIBW_BUILD: cp310-*`)

This produces 4 abi-agnostic wheels (`py3-none-{manylinux x86_64/aarch64, macOS x86_64/arm64}`) that install on **any** Python 3 — including 3.14 and future releases — with no per-version build churn.